### PR TITLE
SPEC-1555 Consider connection pool health during server selection

### DIFF
--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -53,6 +53,13 @@ For convenience, a Thread refers to:
 -  An Execution Frame / Continuation in asynchronous drivers
 -  A goroutine in Go
 
+Active Connection
+~~~~~~~~~~~~~~~~~
+
+An "active Connection" is a `Connection`_ that is either pending or in use. The
+server selection algorithm takes the number of active connections a particular
+server has into account when deciding among suitable choices.
+
 Behavioral Description
 ======================
 
@@ -176,17 +183,7 @@ A driver-defined wrapper around a single TCP connection to an Endpoint. A `Conne
 -  **Single Track:** A `Connection`_ MUST limit itself to one request / response at a time. A `Connection`_ MUST NOT multiplex/pipeline requests to an Endpoint.
 -  **Monotonically Increasing ID:** A `Connection`_ MUST have an ID number associated with it. `Connection`_ IDs within a Pool MUST be assigned in order of creation, starting at 1 and increasing by 1 for each new Connection.
 -  **Valid Connection:** A connection MUST NOT be checked out of the pool until it has successfully and fully completed a MongoDB Handshake and Authentication as specified in the `Handshake <https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.rst>`__, `OP_COMPRESSED <https://github.com/mongodb/specifications/blob/master/source/compression/OP_COMPRESSED.rst>`__, and `Authentication <https://github.com/mongodb/specifications/blob/master/source/auth/auth.rst>`__ specifications.
--  **Perishable**: it is possible for a `Connection`_ to become **Perished**. A `Connection`_ is considered perished if any of the following are true:
-
-   -  **Stale:** The `Connection`_ 's generation does not match the generation of the parent pool
-   -  **Idle:** The `Connection`_ is currently "available" (as defined below) and has been for longer than **maxIdleTimeMS**.
-   -  **Errored:** The `Connection`_ has experienced an error that indicates it is no longer recommended for use. Examples include, but are not limited to:
-
-      -  Network Error
-      -  Network Timeout
-      -  Endpoint closing the connection
-      -  Driver-Side Timeout
-      -  Wire-Protocol Error
+-  **Perishable**: it is possible for a `Connection`_ to become **Perished**. See `Determining if a Connection is "perished"`_ for what this entails. 
 
 .. code:: typescript
 
@@ -263,6 +260,7 @@ has the following properties:
 
 -  **Capped:** a pool is capped if **maxPoolSize** is set to a non-zero value. If a pool is capped, then its total number of `Connections <#connection>`_ (including available and in use) MUST NOT exceed **maxPoolSize**
 -  **Rate-limited:** A Pool MUST limit the number of connections being created at a given time to be 2 (maxConnecting). 
+-  **Live:** A Pool MUST periodically ensure its available `Connections <#connection>`_ are “live”, removing any perished ones it encounters.
 
 
 .. code:: typescript
@@ -295,6 +293,14 @@ has the following properties:
        *  being established.
        */
       pendingConnectionCount: number;
+
+      /**
+       * An integer expressing how many Connections are in-use or
+       * are being established. This is used in server selection.
+       */
+      activeConnectionCount(): number {
+          return (totalConnectionCount - availableConnectionCount) + pendingConnectionCount;
+      }
 
       /**
        *  Returns a Connection for use
@@ -597,6 +603,22 @@ Otherwise, the `Connection <#connection>`_ is marked as available.
       close connection
     else:
       mark connection as available
+
+Determining if a Connection is "perished"
+-----------------------------------------
+
+Before checking out or checking in a `Connection`_, the pool MUST ensure the
+`Connection`_ is not "perished". To do so, it MUST verify it is none of the following:
+
+-  **Stale:** The `Connection`_ 's generation does not match the generation of the parent pool
+-  **Idle:** The `Connection`_ is currently "available" (as defined below) and has been for longer than **maxIdleTimeMS**.
+-  **Errored:** The `Connection`_ has experienced an error that indicates it is no longer recommended for use. To determine if a `Connection`_ is in such a state, the pool MUST check if it is “live” by using poll(), select(), or similar functionality available in the language’s networking library. This check MUST NOT block. This can be achieved by passing a timeout of 0 to poll(), for example. Examples causes of such a state include, but are not limited to:
+
+    -  Network Error
+    -  Network Timeout
+    -  Endpoint closing the connection
+    -  Driver-Side Timeout
+    -  Wire-Protocol Error
 
 Clearing a Connection Pool
 --------------------------

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -10,7 +10,7 @@ Connection Monitoring and Pooling
 :Type: Standards
 :Minimum Server Version: N/A
 :Last Modified: September 24, 2020
-:Version: 1.3.0
+:Version: 1.4.0
 
 .. contents::
 
@@ -955,6 +955,8 @@ Exhaust Cursors may require changes to how we close `Connections <#connection>`_
 
 Change log
 ==========
+:2020-10-10: Require liveness checking of pooled Connections
+
 :2020-09-24: Introduce maxConnecting requirement
 
 :2020-09-03: Clarify Connection states and definition. Require the use of a

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -621,7 +621,7 @@ considered "perished" if it is at least one of the following:
    -  Driver-Side Timeout
    -  Wire-Protocol Error
 
--  **Dead:** The `Connection`_ is currently "available" but has become unusable (e.g. due to server closing other end or a network disruption). To determine if a `Connection`_ is in such a state, the pool MUST check if it is “live” by using poll(), select(), or similar functionality available in the language’s networking library. This check MUST NOT block. This can be achieved by passing a timeout of 0 to poll(), for example.
+-  **Dead:** The `Connection`_ is currently "available" but has become unusable (e.g. due to the endpoint closing the other end of the underlying TCP socket or a network disruption). To determine if a `Connection`_ is in such a state, the pool MUST check if it is “live” by using poll(), select(), or similar functionality available in the language’s networking library. This check MUST NOT block. This can be achieved by passing a timeout of 0 to poll(), for example.
 
 Clearing a Connection Pool
 --------------------------

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -613,13 +613,13 @@ considered "perished" if it is at least one of the following:
 
 -  **Stale:** The `Connection`_ 's generation does not match the generation of the parent pool
 -  **Idle:** The `Connection`_ is currently "available" and has been for longer than **maxIdleTimeMS**.
--  **Errored:** The `Connection`_ has experienced an error that indicates it is no longer recommended for use. To determine if a `Connection`_ is in such a state, the pool MUST check if it is “live” by using poll(), select(), or similar functionality available in the language’s networking library. This check MUST NOT block. This can be achieved by passing a timeout of 0 to poll(), for example. Examples of how a `Connection`_ might enter such a state include, but are not limited to:
+-  **Errored:** The `Connection`_ has experienced an error that indicates it is no longer recommended for use. To determine if a `Connection`_ is in such a state, the pool MUST check if it is “live” by using poll(), select(), or similar functionality available in the language’s networking library. This check MUST NOT block. This can be achieved by passing a timeout of 0 to poll(), for example. Examples of how a `Connection`_ might enter such a state include, but are not limited to: 
 
-    -  Network Error
-    -  Network Timeout
-    -  Endpoint closing the connection
-    -  Driver-Side Timeout
-    -  Wire-Protocol Error
+   -  Network Error
+   -  Network Timeout
+   -  Endpoint closing the connection
+   -  Driver-Side Timeout
+   -  Wire-Protocol Error
 
 Clearing a Connection Pool
 --------------------------

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -58,7 +58,7 @@ Active Connection
 
 An "active Connection" is a `Connection`_ that is either pending or in use. The
 server selection algorithm takes the number of active connections a particular
-server has into account when deciding among suitable choices.
+pool has into account when deciding among suitable choices.
 
 Behavioral Description
 ======================

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -607,12 +607,13 @@ Otherwise, the `Connection <#connection>`_ is marked as available.
 Determining if a Connection is "perished"
 -----------------------------------------
 
-Before checking out or checking in a `Connection`_, the pool MUST ensure the
-`Connection`_ is not "perished". To do so, it MUST verify it is none of the following:
+Before checking a `Connection`_ in or out, the pool MUST
+ensure the `Connection`_ is not "perished". A `Connection`_ is
+considered "perished" if it is at least one of the following:
 
 -  **Stale:** The `Connection`_ 's generation does not match the generation of the parent pool
--  **Idle:** The `Connection`_ is currently "available" (as defined below) and has been for longer than **maxIdleTimeMS**.
--  **Errored:** The `Connection`_ has experienced an error that indicates it is no longer recommended for use. To determine if a `Connection`_ is in such a state, the pool MUST check if it is “live” by using poll(), select(), or similar functionality available in the language’s networking library. This check MUST NOT block. This can be achieved by passing a timeout of 0 to poll(), for example. Examples causes of such a state include, but are not limited to:
+-  **Idle:** The `Connection`_ is currently "available" and has been for longer than **maxIdleTimeMS**.
+-  **Errored:** The `Connection`_ has experienced an error that indicates it is no longer recommended for use. To determine if a `Connection`_ is in such a state, the pool MUST check if it is “live” by using poll(), select(), or similar functionality available in the language’s networking library. This check MUST NOT block. This can be achieved by passing a timeout of 0 to poll(), for example. Examples of how a `Connection`_ might enter such a state include, but are not limited to:
 
     -  Network Error
     -  Network Timeout

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -613,13 +613,15 @@ considered "perished" if it is at least one of the following:
 
 -  **Stale:** The `Connection`_ 's generation does not match the generation of the parent pool
 -  **Idle:** The `Connection`_ is currently "available" and has been for longer than **maxIdleTimeMS**.
--  **Errored:** The `Connection`_ has experienced an error that indicates it is no longer recommended for use. To determine if a `Connection`_ is in such a state, the pool MUST check if it is “live” by using poll(), select(), or similar functionality available in the language’s networking library. This check MUST NOT block. This can be achieved by passing a timeout of 0 to poll(), for example. Examples of how a `Connection`_ might enter such a state include, but are not limited to: 
+-  **Errored:** The `Connection`_ has experienced an error that indicates it is no longer recommended for use. Examples of how a `Connection`_ might enter such a state include, but are not limited to:
 
    -  Network Error
    -  Network Timeout
    -  Endpoint closing the connection
    -  Driver-Side Timeout
    -  Wire-Protocol Error
+
+-  **Dead:** The `Connection`_ is currently "available" but has become unusable (e.g. due to server closing other end or a network disruption). To determine if a `Connection`_ is in such a state, the pool MUST check if it is “live” by using poll(), select(), or similar functionality available in the language’s networking library. This check MUST NOT block. This can be achieved by passing a timeout of 0 to poll(), for example.
 
 Clearing a Connection Pool
 --------------------------

--- a/source/server-selection/server-selection-tests.rst
+++ b/source/server-selection/server-selection-tests.rst
@@ -217,45 +217,23 @@ correctly passed to Mongos in the following scenarios:
   - $readPreference is used
 
 
-Random Selection Within Latency Window
-======================================
+Selection Within Latency Window
+===============================
 
-The Server Selection spec mandates that drivers select a server at random from the
-set of suitable servers that are within the latency window. Drivers implementing the
-spec SHOULD test their implementations in a language-specific way to confirm randomness.
+The Server Selection spec mandates that drivers select a server from within the
+latency window according to a certain algorithm. There are YAML tests verifying
+that drivers implement this algorithm correctly. Drivers implementing the spec
+MUST use them test their implementations.
 
-For example, the following topology description, operation, and read preference will
-return a set of three suitable servers within the latency window::
+The tests each include some information about the servers within the latency
+window. For each case, the driver passes this information into whatever function
+it uses to select from within the window. Because the algorithm relies on
+randomness, this process MUST be repeated 1000 times. Once the 1000 selections
+are complete, the runner tallies up the number of times each server was selected
+and compares those counts to the expected results included in the test
+case. Specifics of the test format and how to run the tests are included in the
+tests README.
 
-   topology_description:
-     type: ReplicaSetWithPrimary
-     servers:
-     - &secondary_1
-       address: b:27017
-       avg_rtt_ms: 5
-       type: RSSecondary
-       tags: {}
-     - &secondary_2
-       address: c:27017
-       avg_rtt_ms: 10
-       type: RSSecondary
-       tags: {}
-     - &primary
-       address: a:27017
-       avg_rtt_ms: 6
-       type: RSPrimary
-       tags: {}
-   operation: read
-   read_preference:
-     mode: Nearest
-     tags: {}
-   in_latency_window:
-   - *primary
-   - *secondary_1
-   - *secondary_2
-
-Drivers SHOULD check that their implementation selects one of ``primary``, ``secondary_1``,
-and ``secondary_2`` at random.
 
 Application-Provided Server Selector
 ====================================

--- a/source/server-selection/server-selection.rst
+++ b/source/server-selection/server-selection.rst
@@ -1055,7 +1055,8 @@ slight modification of the `"Power of Two Random Choices with Min Connections"
 load balancing algorithm. The steps are as follows:
 
 1. Select two servers at random from the set of available servers in the latency
-   window
+   window. If there is only 1 server in the latency window, just return that server
+   without proceeding to the next steps.
 
 2. If ``abs(server1.pool.activeConnectionCount - server2.pool.activeConnectionCount) > 0.05*maxPoolSize``,
    then choose the server with the smaller ``activeConnectionCount``.

--- a/source/server-selection/server-selection.rst
+++ b/source/server-selection/server-selection.rst
@@ -1766,8 +1766,8 @@ References
 .. _Max Staleness: https://github.com/mongodb/specifications/tree/master/source/max-staleness
 .. _idleWritePeriodMS: https://github.com/mongodb/specifications/blob/master/source/max-staleness/max-staleness.rst#idlewriteperiodms
 .. _Driver Authentication: https://github.com/mongodb/specifications/blob/master/source/auth
-.. _Connection Pool: https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#connection-pool
-.. _Connection Monitoring and Pooling: https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#connection-pool
+.. _Connection Pool: /source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#connection-pool
+.. _Connection Monitoring and Pooling: /source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
 
 Changes
 =======

--- a/source/server-selection/server-selection.rst
+++ b/source/server-selection/server-selection.rst
@@ -823,10 +823,6 @@ as follows:
 
 8. Goto Step #2
 
-Load balancing algorithm
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-
 
 Single-threaded server selection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1067,8 +1063,8 @@ load balancing algorithm. The steps are as follows:
 
 3. Otherwise, choose the server with the higher availableConnectionCount.
 
-See the `Connection Pool_` definition in CMAP for the definitions of
-availableConnectionCount and activeConnectionCount.
+See the `Connection Pool`_ definition in the CMAP specification for the
+definitions of availableConnectionCount and activeConnectionCount.
 
 
 Checking an Idle Socket After socketCheckIntervalMS

--- a/source/server-selection/server-selection.rst
+++ b/source/server-selection/server-selection.rst
@@ -1058,7 +1058,7 @@ load balancing algorithm. The steps are as follows:
    window. If there is only 1 server in the latency window, just return that server
    without proceeding to the next steps.
 
-2. If ``abs(server1.pool.activeConnectionCount - server2.pool.activeConnectionCount) > 0.05*maxPoolSize``,
+2. If ``abs(server1.pool.activeConnectionCount - server2.pool.activeConnectionCount) > max(0.05*maxPoolSize, 1)``,
    then choose the server with the smaller ``activeConnectionCount``.
 
 3. Otherwise, choose the server with the higher ``availableConnectionCount``.

--- a/source/server-selection/server-selection.rst
+++ b/source/server-selection/server-selection.rst
@@ -1736,8 +1736,8 @@ Node 2.
 Why change from pure random selection when selecting from within the latency window?
 ------------------------------------------------------------------------------------
 
-When a node slows down, pooled connections against will remain checked
-out for longer periods of time due to operations taking longer to complete
+When a node slows down, pooled connections to it will remain checked out for
+longer periods of time due to operations taking longer to complete
 server-side. Assuming at least constant incoming operation load, more
 connections will need to be opened against the node to service new operations,
 further straining it and slowing it down. This can lead to runaway connection
@@ -1745,10 +1745,10 @@ creation scenarios that can cripple a deployment ("connnection storms"). As part
 of DRIVERS-781, the load balancing algorithm was changed to more evenly spread
 out the workload among suitable servers to prevent any single node from being
 overloaded. The new algorithm achieves this by routing operations to servers
-with fewer active connections, thereby reducing new operations and connection
-creations against nodes that are busier. The previous random selection mechanism
-did not take load into account and could assign work to nodes that were under
-too much stress already.
+with fewer active connections, thereby reducing the number of new operations and
+connection creations routed towards nodes that are busier. The previous random
+selection mechanism did not take load into account and could assign work to
+nodes that were under too much stress already.
 
 As an added benefit, the new algorithm gives preference to nodes that have
 recently been discovered and are thus are more likely to be alive (e.g. during a

--- a/source/server-selection/server-selection.rst
+++ b/source/server-selection/server-selection.rst
@@ -10,7 +10,7 @@ Server Selection
 :Status: Accepted
 :Type: Standards
 :Last Modified: 2020-03-17
-:Version: 1.11.0
+:Version: 1.12.0
 
 .. contents::
 
@@ -1821,6 +1821,9 @@ selection rules.
 2019-06-07: Clarify language for aggregate and mapReduce commands that write
 
 2020-03-17: Specify read preferences with support for server hedged reads
+
+2020-10-10: Consider connection pool health when selecting servers within the
+latency window.
 
 .. [#] mongos 3.4 refuses to connect to mongods with maxWireVersion < 5,
    so it does no additional wire version checks related to maxStalenessSeconds.

--- a/source/server-selection/server-selection.rst
+++ b/source/server-selection/server-selection.rst
@@ -1057,11 +1057,10 @@ load balancing algorithm. The steps are as follows:
 1. Select two servers at random from the set of available servers in the latency
    window
 
-2. If abs(server1.pool.activeConnectionCount -
-   server2.pool.activeConnectionCount) > 0.05*maxPoolSize, then choose the
-   server with the smaller activeConnectionCount.
+2. If ``abs(server1.pool.activeConnectionCount - server2.pool.activeConnectionCount) > 0.05*maxPoolSize``,
+   then choose the server with the smaller ``activeConnectionCount``.
 
-3. Otherwise, choose the server with the higher availableConnectionCount.
+3. Otherwise, choose the server with the higher ``availableConnectionCount``.
 
 See the `Connection Pool`_ definition in the CMAP specification for the
 definitions of availableConnectionCount and activeConnectionCount.

--- a/source/server-selection/tests/README.rst
+++ b/source/server-selection/tests/README.rst
@@ -74,7 +74,7 @@ Each YAML file for these tests has the following format:
 - ``in_window``: array of servers in the latency window that the selected server
   is to be chosen from. Each element will have all of the following fields:
 
-  - ``id``: a unique string identifier for this server
+  - ``address``: a unique address identifying this server
 
   - ``active_connection_count``: the number of active connections this server
     currently has open
@@ -85,7 +85,7 @@ Each YAML file for these tests has the following format:
 - ``max_pool_size``: the maximum number of connections allowed in a server's
   connection pool.
 
-- ``expected_frequencies``: a document whose keys are the server ids from the
+- ``expected_frequencies``: a document whose keys are the server addresses from the
   ``in_window`` array and values are numbers in [0, 1] indicating the frequency
   at which the server should have been selected.
 

--- a/source/server-selection/tests/README.rst
+++ b/source/server-selection/tests/README.rst
@@ -71,6 +71,8 @@ Selection Within Latency Window Tests
 
 Each YAML file for these tests has the following format:
 
+- ``topology_description``: the state of a mocked cluster
+
 - ``in_window``: array of servers in the latency window that the selected server
   is to be chosen from. Each element will have all of the following fields:
 
@@ -97,4 +99,6 @@ contained in ``expected_frequencies`` for that server. If the expected frequency
 for a given server is 1 or 0, then the observed frequency MUST be exactly equal
 to the expected one.
 
-Mocking may be required to implement these tests.
+Mocking may be required to implement these tests. A mocked topology description
+is included in each file for drivers that require a full description to
+implement these tests.

--- a/source/server-selection/tests/README.rst
+++ b/source/server-selection/tests/README.rst
@@ -65,3 +65,36 @@ the TopologyDescription. Each YAML file contains a key for these stages of serve
 Drivers implementing server selection MUST test that their implementation
 correctly returns the set of servers in ``in_latency_window``. Drivers SHOULD also test
 against ``suitable_servers`` if possible.
+
+Selection Within Latency Window Tests
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+
+Each YAML file for these tests has the following format:
+
+- ``in_window``: array of servers in the latency window that the selected server
+  is to be chosen from. Each element will have all of the following fields:
+
+  - ``id``: a unique string identifier for this server
+
+  - ``active_connection_count``: the number of active connections this server
+    currently has open
+
+  - ``available_connection_count``: the number of available connections this
+    server currently has in its pool.
+
+- ``max_pool_size``: the maximum number of connections allowed in a server's
+  connection pool.
+
+- ``expected_frequencies``: a document whose keys are the server ids from the
+  ``in_window`` array and values are numbers in [0, 1] indicating the frequency
+  at which the server should have been selected.
+
+For each file, pass the information from `in_window` to whatever function is
+used to select a server from within the latency window 1000 times, counting how
+many times each server is selected.  Once 1000 selectoins have been made, verify
+that each server was selected at a frequency within 0.05 of the frequency
+contained in ``expected_frequencies`` for that server. If the expected frequency
+for a given server is 1 or 0, then the observed frequency MUST be exactly equal
+to the expected one.
+
+Mocking may be required to implement these tests.

--- a/source/server-selection/tests/in_window/three-choices.json
+++ b/source/server-selection/tests/in_window/three-choices.json
@@ -1,0 +1,26 @@
+{
+  "description": "Server with least connections and most available connections selected most",
+  "in_window": [
+    {
+      "id": "a",
+      "active_connection_count": 3,
+      "available_connection_count": 0
+    },
+    {
+      "id": "b",
+      "active_connection_count": 6,
+      "available_connection_count": 1
+    },
+    {
+      "id": "c",
+      "active_connection_count": "20,",
+      "available_connection_count": 0
+    }
+  ],
+  "max_pool_size": 100,
+  "expected_frequencies": {
+    "a": 0.66,
+    "b": 0.33,
+    "c": 0
+  }
+}

--- a/source/server-selection/tests/in_window/three-choices.json
+++ b/source/server-selection/tests/in_window/three-choices.json
@@ -2,25 +2,25 @@
   "description": "Server with least connections and most available connections selected most",
   "in_window": [
     {
-      "id": "a",
+      "address": "a:27017",
       "active_connection_count": 3,
       "available_connection_count": 0
     },
     {
-      "id": "b",
+      "address": "b:27017",
       "active_connection_count": 6,
       "available_connection_count": 1
     },
     {
-      "id": "c",
+      "address": "c:27017",
       "active_connection_count": "20,",
       "available_connection_count": 0
     }
   ],
   "max_pool_size": 100,
   "expected_frequencies": {
-    "a": 0.66,
-    "b": 0.33,
-    "c": 0
+    "a:27017": 0.66,
+    "b:27017": 0.33,
+    "c:27017": 0
   }
 }

--- a/source/server-selection/tests/in_window/three-choices.json
+++ b/source/server-selection/tests/in_window/three-choices.json
@@ -1,5 +1,25 @@
 {
   "description": "Server with least connections and most available connections selected most",
+  "topology_description": {
+    "type": "Sharded",
+    "servers": [
+      {
+        "address": "a:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "b:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "c:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      }
+    ]
+  },
   "in_window": [
     {
       "address": "a:27017",

--- a/source/server-selection/tests/in_window/three-choices.yml
+++ b/source/server-selection/tests/in_window/three-choices.yml
@@ -3,23 +3,23 @@ in_window:
     # chosen when randomly selected with c due to
     # lower active count. loses tie to b due to lower
     # available connection count
-    - id: a
+    - address: a:27017
       active_connection_count: 3
       available_connection_count: 0
 
     # should be selected whenever randomly chosen due to
     # higher available connection count
-    - id: b
+    - address: b:27017
       active_connection_count: 6
       available_connection_count: 1
 
     # should never be selected due to high active count
-    - id: c
+    - address: c:27017
       active_connection_count: 20,
       available_connection_count: 0
 
 max_pool_size: 100
 expected_frequencies:
-    a: 0.66
-    b: 0.33
-    c: 0
+    a:27017: 0.66
+    b:27017: 0.33
+    c:27017: 0

--- a/source/server-selection/tests/in_window/three-choices.yml
+++ b/source/server-selection/tests/in_window/three-choices.yml
@@ -1,0 +1,25 @@
+description: Server with least connections and most available connections selected most
+in_window:
+    # chosen when randomly selected with c due to
+    # lower active count. loses tie to b due to lower
+    # available connection count
+    - id: a
+      active_connection_count: 3
+      available_connection_count: 0
+
+    # should be selected whenever randomly chosen due to
+    # higher available connection count
+    - id: b
+      active_connection_count: 6
+      available_connection_count: 1
+
+    # should never be selected due to high active count
+    - id: c
+      active_connection_count: 20,
+      available_connection_count: 0
+
+max_pool_size: 100
+expected_frequencies:
+    a: 0.66
+    b: 0.33
+    c: 0

--- a/source/server-selection/tests/in_window/three-choices.yml
+++ b/source/server-selection/tests/in_window/three-choices.yml
@@ -1,4 +1,16 @@
 description: Server with least connections and most available connections selected most
+topology_description:
+  type: Sharded
+  servers:
+  - address: a:27017
+    avg_rtt_ms: 35
+    type: Mongos
+  - address: b:27017
+    avg_rtt_ms: 35
+    type: Mongos
+  - address: c:27017
+    avg_rtt_ms: 35
+    type: Mongos
 in_window:
     # chosen when randomly selected with c due to
     # lower active count. loses tie to b due to lower


### PR DESCRIPTION
SPEC-1555

DRAFT

This PR updates the Server Selection algorithm to consider connection pool health as per the design in DRIVERS-781. It also updates the CMAP spec to require liveness checking of pooled connections. I have yet to write spec tests for this yet, but I figured it was still worth having a look over the prose.

This PR is currently based off of my maxConnecting PR. I'll open a new one against the mongodb repo once that PR gets merged.